### PR TITLE
Docker ordered dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM continuumio/miniconda3 AS MELDgraph
+FROM debian:12.5-slim AS MELDgraph
 
 ENV DEBIAN_FRONTEND="noninteractive"
 ARG CONDA_FILE=Miniconda3-py38_4.11.0-Linux-x86_64.sh
@@ -6,16 +6,15 @@ ARG CONDA_FILE=Miniconda3-py38_4.11.0-Linux-x86_64.sh
 ## Expensive calls that don't change go up top. See https://docs.docker.com/build/cache/
 
 #pdate the ubuntu.
-RUN apt-get -y update && apt-get -y upgrade
-
-RUN apt-get install -y build-essential apt-utils curl wget
+RUN --mount=type=cache,target=/var/cache/apt apt-get -y update && apt-get install -y build-essential apt-utils curl wget git
 
 #Install freesurfer in /opt/freesurfer
 #TODO: need to get freesurfer from wget
-RUN echo "Downloading FreeSurfer ..." \
-   && mkdir -p /opt/freesurfer-7.2.0 \
-   && curl -fL https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/7.2.0/freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz \
-    | tar -xz -C /opt/freesurfer-7.2.0 --owner root --group root --no-same-owner --strip-components 1 \
+RUN echo "Downloading FreeSurfer..."
+RUN mkdir -p /opt/freesurfer-7.2.0
+RUN --mount=type=cache,target=/cache/download --mount=type=cache,target=/opt/freesurfer-7.2.0 cp -f /opt/freesurfer-7.2.0/freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz /cache/download
+RUN --mount=type=cache,target=/cache/download wget -c -O /cache/download/freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz --progress=bar:force https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/7.2.0/freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz
+RUN --mount=type=cache,target=/cache/download tar -xzf /cache/download/freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz -C /opt/freesurfer-7.2.0 --owner root --group root --no-same-owner --strip-components 1 \
          --exclude='average/mult-comp-cor' \
          --exclude='lib/cuda' \
          --exclude='lib/qt' \
@@ -28,8 +27,7 @@ RUN echo "Downloading FreeSurfer ..." \
          --exclude='subjects/fsaverage5' \
          --exclude='subjects/fsaverage6' \
          --exclude='trctrain'
-
-RUN rm -f /opt/freesurfer-7.2.0/freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz
+         
 
 # COPY freesurfer/ /opt/freesurfer-7.2.0
 
@@ -41,28 +39,34 @@ RUN echo "FREESURFER_HOME=/opt/freesurfer-7.2.0" >> ~/.bashrc
 RUN echo "FS_LICENSE=/license.txt" >> ~/.bashrc
 
 # Install Fastsurfer
-RUN mkdir -p /fastsurfer \
+RUN  mkdir -p /fastsurfer \
 && git clone --branch v1.1.2 https://github.com/Deep-MI/FastSurfer.git /opt/fastsurfer-v1.1.2 
 RUN echo "export PYTHONPATH=\"\${PYTHONPATH}:$PWD\"" >> ~/.bashrc
 ENV FASTSURFER_HOME=/opt/fastsurfer-v1.1.2
 RUN echo "FASTSURFER_HOME=/opt/fastsurfer-v1.1.2" >> ~/.bashrc
 
 #Install the prerequisite software
-RUN apt-get install -y build-essential \
+RUN --mount=type=cache,target=/var/cache/apt apt-get install -y build-essential \
     apt-utils \
+     pip \
+     python3 \
+     time \
+    bc
 #     vim \
 #     nano \
-    curl \
-    wget \
-    git \
-    time \
-# 	csh \
+#  	csh \
 # 	tcsh \
-    bc
 
 # Add conda to path
 ENV CONDA_DIR /opt/conda
 ENV PATH=$CONDA_DIR/bin:$PATH
+
+
+# Install miniconda
+RUN wget --no-check-certificate -qO ~/miniconda.sh https://repo.continuum.io/miniconda/$CONDA_FILE  && \
+     chmod +x ~/miniconda.sh && \
+     ~/miniconda.sh -b -p /opt/conda && \
+     rm ~/miniconda.sh 
 
 # Update conda
 RUN conda update -n base -c defaults conda

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN --mount=type=cache,target=/var/cache/apt apt-get install -y build-essential 
     time \
     tcsh \
     vim \
- 	  csh \
+    csh \
     bc
 #     nano \
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,19 +54,11 @@ RUN apt-get install -y build-essential \
 #     nano \
     curl \
     wget \
-#     pip \ 
-#     python3 \
     git \
     time \
 # 	csh \
 # 	tcsh \
     bc
-
-# # Install miniconda
-# RUN wget --no-check-certificate -qO ~/miniconda.sh https://repo.continuum.io/miniconda/$CONDA_FILE  && \
-#      chmod +x ~/miniconda.sh && \
-#      ~/miniconda.sh -b -p /opt/conda && \
-#      rm ~/miniconda.sh 
 
 # Add conda to path
 ENV CONDA_DIR /opt/conda
@@ -81,21 +73,22 @@ SHELL ["/bin/bash", "-c"]
 
 # Add meld_graph code 
 RUN mkdir /app
-COPY ./data /app/data
-COPY ./notebooks /app/notebooks
-COPY ./meld_graph /app/meld_graph
-COPY ./entrypoint.sh /app/
-COPY ./meld_config.ini /app/
-COPY ./environment.yml /app/
-COPY ./MELD_logo.png /app/
-COPY ./pyproject.toml /app/
-COPY ./pytest.ini /app/
-COPY ./setup.py /app/
+
+# COPY ./data /app/data
+# COPY ./notebooks /app/notebooks
+# COPY ./meld_graph /app/meld_graph
+# COPY ./entrypoint.sh /app/
+# COPY ./meld_config.ini /app/
+# COPY ./environment.yml /app/
+# COPY ./MELD_logo.png /app/
+# COPY ./pyproject.toml /app/
+# COPY ./pytest.ini /app/
+# COPY ./setup.py /app/
 
 # Define working directory
 WORKDIR /app
 
-# RUN cd /app/ && git clone --branch dev_docker https://github.com/MELDProject/meld_graph.git .
+RUN git clone --branch dev_docker https://github.com/MELDProject/meld_graph.git .
 # Update current conda base environment with packages for meld_graph 
 RUN --mount=type=cache,target=/opt/conda/pkgs conda env create -f environment.yml
 
@@ -104,7 +97,7 @@ SHELL ["conda", "run", "-n", "meld_graph", "/bin/bash", "-c"]
 # Install meld_graph package
 RUN conda run -n meld_graph /bin/bash -c "pip install -e ."
 
-COPY ./scripts /app/scripts
+# COPY ./scripts /app/scripts
 
 # Add data folder to docker
 RUN mkdir /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN --mount=type=cache,target=/var/cache/apt apt-get -y update && apt-get instal
 RUN echo "Downloading FreeSurfer..."
 RUN mkdir -p /opt/freesurfer-7.2.0
 RUN --mount=type=cache,target=/cache/download wget -N -O /cache/download/freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz --progress=bar:force https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/7.2.0/freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz
-RUN --mount=type=cache,target=/cache/download tar -xzf /cache/download/freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz -C /opt/freesurfer-7.2.0 --owner root --group root --no-same-owner --strip-components 1 \
+RUN --mount=type=cache,target=/cache/download tar -xzf /cache/download/freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz -C /opt/freesurfer-7.2.0 --owner root --group root --no-same-owner --strip-components 1 --keep-newer-files \
          --exclude='average/mult-comp-cor' \
          --exclude='lib/cuda' \
          --exclude='lib/qt' \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN --mount=type=cache,target=/var/cache/apt apt-get -y update && apt-get instal
 #TODO: need to get freesurfer from wget
 RUN echo "Downloading FreeSurfer..."
 RUN mkdir -p /opt/freesurfer-7.2.0
-RUN --mount=type=cache,target=/cache/download wget -c -O /cache/download/freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz --progress=bar:force https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/7.2.0/freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz
+RUN --mount=type=cache,target=/cache/download wget -N -O /cache/download/freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz --progress=bar:force https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/7.2.0/freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz
 RUN --mount=type=cache,target=/cache/download tar -xzf /cache/download/freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz -C /opt/freesurfer-7.2.0 --owner root --group root --no-same-owner --strip-components 1 \
          --exclude='average/mult-comp-cor' \
          --exclude='lib/cuda' \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG CONDA_FILE=Miniconda3-py38_4.11.0-Linux-x86_64.sh
 
 ## Expensive calls that don't change go up top. See https://docs.docker.com/build/cache/
 
-#pdate the ubuntu.
+#Update the ubuntu.
 RUN --mount=type=cache,target=/var/cache/apt apt-get -y update && apt-get install -y build-essential apt-utils curl wget git
 
 #Install freesurfer in /opt/freesurfer


### PR DESCRIPTION
Shuffles around a couple things to make it easier to iterate on the container and scripts. Most changes were prompted by https://docs.docker.com/build/cache/.

- Changes to a miniconda base image and comments out the relevant packages from apt-get and the miniconda install
- Moves the freesurfer install to the top to avoid the big download (this could also be `--mount=type=cache` ified, but I didn't want to redownload in order to do that
- comments out some convenience packages like vim, nano, and shells
-  `--mount=type=cache` ifies the conda install to reuse `/opt/conda/pkgs` between builds even if the conda requirements change
- explicitly copies all relevant files so that the scripts folder can be copied after the conda env. This lets docker rebuild after the conda env line and saves a bunch of time while iterating on scripts. 