### PR TITLE
Multi-stage docker and cpuonly conda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,28 +7,26 @@ FROM debian:12-slim AS freesurfer
 RUN apt-get -y update && apt-get install --no-install-recommends -y wget && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 #Install freesurfer in /opt/freesurfer
-RUN echo "Downloading FreeSurfer..."
 RUN mkdir -p /opt/freesurfer-7.2.0
 
+# Download freesurfer
 RUN wget -N -O --no-check-certificate freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz --progress=bar:force https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/7.2.0/freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz && \
-# COPY freesurfer.tar.gz freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz
-RUN  tar -xzf freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz -C /opt/freesurfer-7.2.0 --owner root --group root --no-same-owner --strip-components 1 --keep-newer-files \
-          --exclude='average/mult-comp-cor' \
-          --exclude='lib/cuda' \
-          --exclude='lib/qt' \
-          --exclude='subjects/V1_average' \
-          --exclude='subjects/bert' \
-          --exclude='subjects/cvs_avg35' \
-          --exclude='subjects/cvs_avg35_inMNI152' \
-          --exclude='subjects/fsaverage3' \
-          --exclude='subjects/fsaverage4' \
-          --exclude='subjects/fsaverage5' \
-          --exclude='subjects/fsaverage6' \
-          --exclude='trctrain'
+    tar -xzf freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz -C /opt/freesurfer-7.2.0 --owner root --group root --no-same-owner --strip-components 1 --keep-newer-files \
+    --exclude='average/mult-comp-cor' \
+    --exclude='lib/cuda' \
+    --exclude='lib/qt' \
+    --exclude='subjects/V1_average' \
+    --exclude='subjects/bert' \
+    --exclude='subjects/cvs_avg35' \
+    --exclude='subjects/cvs_avg35_inMNI152' \
+    --exclude='subjects/fsaverage3' \
+    --exclude='subjects/fsaverage4' \
+    --exclude='subjects/fsaverage5' \
+    --exclude='subjects/fsaverage6' \
+    --exclude='trctrain' && \
+    rm freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz
 
-
-# micromamba stage
-
+# fetch source stage
 FROM  debian:12-slim AS meld_git
 
 #Update the ubuntu.
@@ -45,17 +43,15 @@ USER root
 ENV MAMBA_ROOT_PREFIX="/opt/conda"
 ENV MAMBA_EXE="/bin/micromamba"
 
-#Update the ubuntu.
+#Update ubuntu.
 RUN apt-get -y update && apt-get install --no-install-recommends -y wget gcc g++ && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN mkdir /tmp/pkg
 WORKDIR /tmp
 
-
 RUN wget https://github.com/MELDProject/meld_graph/raw/dev_docker/environment.yml
-# COPY environment.yml .
 
-# RUN --mount=type=cache,target=/opt/conda/pkgs \
+# Create the meld_graph environment
 RUN micromamba create -y -f environment.yml \
     && micromamba clean -afy
 
@@ -63,6 +59,8 @@ RUN micromamba create -y -f environment.yml \
 # meld graph stage
 FROM python:3.9-slim AS MELDgraph
 RUN mkdir -p /opt/freesurfer-7.2.0
+
+# Copy over freesurfer from the freesurfer stage without the apt packages and tar file
 COPY --from=freesurfer /opt/freesurfer-7.2.0 /opt/freesurfer-7.2.0
 
 ENV DEBIAN_FRONTEND="noninteractive"
@@ -85,8 +83,6 @@ RUN apt-get -y update && \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# COPY freesurfer/ /opt/freesurfer-7.2.0
-
 # #Modify the environment with Freesurfer paths
 ENV PATH=/opt/freesurfer-7.2.0/bin:$PATH
 RUN echo "PATH=/opt/freesurfer-7.2.0/bin:$PATH" >> ~/.bashrc
@@ -105,18 +101,16 @@ RUN echo "FASTSURFER_HOME=/opt/fastsurfer-v1.1.2" >> ~/.bashrc
 ENV CONDA_DIR /opt/conda
 ENV PATH=$CONDA_DIR/bin:$PATH
 
-
-# COPY ./environment.yml .
-
+# Copy the micromamba bin and env
 COPY --from=micromamba /bin/micromamba /bin/micromamba
 COPY --from=micromamba /opt/conda/envs/meld_graph /opt/conda/envs/meld_graph
 
-# Add meld_graph code 
 RUN mkdir /app
 
 # Define working directory
 WORKDIR /app
 
+# Add meld_graph code 
 COPY --from=meld_git /meld_graph .
 
 ENV MAMBA_ROOT_PREFIX="/opt/conda"
@@ -125,24 +119,6 @@ RUN micromamba run -n meld_graph /bin/bash -c "pip install -e ." \
     && micromamba shell init -s bash \
     && echo "micromamba activate meld_graph" >> ~/.bashrc
 
-# COPY ./data data
-# COPY ./notebooks notebooks
-# COPY ./entrypoint.sh .
-# COPY ./meld_config.ini .
-# COPY ./MELD_logo.png .
-# COPY ./pyproject.toml .
-# COPY ./pytest.ini .
-# COPY ./setup.py .
-
-# Activate environment with shell because not working wih conda
-# SHELL ["conda", "run", "-n", "meld_graph", "/bin/bash", "-c"]
-
-# COPY ./meld_graph /app/meld_graph
-
-# Install meld_graph package
-# RUN conda run -n meld_graph /bin/bash -c "pip install -e ."
-
-# COPY ./scripts /app/scripts
 
 # Add data folder to docker
 RUN mkdir /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get -y update && apt-get install --no-install-recommends -y wget && apt-
 RUN echo "Downloading FreeSurfer..."
 RUN mkdir -p /opt/freesurfer-7.2.0
 
-# RUN wget -N -O freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz --progress=bar:force https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/7.2.0/freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz && \
-COPY freesurfer.tar.gz freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz
+RUN wget -N -O --no-check-certificate freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz --progress=bar:force https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/7.2.0/freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz && \
+# COPY freesurfer.tar.gz freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz
 RUN  tar -xzf freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz -C /opt/freesurfer-7.2.0 --owner root --group root --no-same-owner --strip-components 1 --keep-newer-files \
           --exclude='average/mult-comp-cor' \
           --exclude='lib/cuda' \
@@ -48,14 +48,12 @@ ENV MAMBA_EXE="/bin/micromamba"
 #Update the ubuntu.
 RUN apt-get -y update && apt-get install --no-install-recommends -y wget gcc g++ && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-
-
 RUN mkdir /tmp/pkg
 WORKDIR /tmp
 
-COPY environment.yml .
 
-ARG CACHEBUST=1
+RUN wget https://github.com/MELDProject/meld_graph/raw/dev_docker/environment.yml
+# COPY environment.yml .
 
 # RUN --mount=type=cache,target=/opt/conda/pkgs \
 RUN micromamba create -y -f environment.yml \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,89 @@
-FROM debian:12.5-slim AS MELDgraph
-
-ENV DEBIAN_FRONTEND="noninteractive"
-ARG CONDA_FILE=Miniconda3-py38_4.11.0-Linux-x86_64.sh
-
 ## Expensive calls that don't change go up top. See https://docs.docker.com/build/cache/
 
+# freesurfer stage 
+FROM debian:12-slim AS freesurfer
+
 #Update the ubuntu.
-RUN --mount=type=cache,target=/var/cache/apt apt-get -y update && apt-get install -y build-essential apt-utils curl wget git
+RUN apt-get -y update && apt-get install --no-install-recommends -y wget && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 #Install freesurfer in /opt/freesurfer
-#TODO: need to get freesurfer from wget
 RUN echo "Downloading FreeSurfer..."
 RUN mkdir -p /opt/freesurfer-7.2.0
-RUN --mount=type=cache,target=/cache/download wget -N -O /cache/download/freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz --progress=bar:force https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/7.2.0/freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz
-RUN --mount=type=cache,target=/cache/download tar -xzf /cache/download/freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz -C /opt/freesurfer-7.2.0 --owner root --group root --no-same-owner --strip-components 1 --keep-newer-files \
-         --exclude='average/mult-comp-cor' \
-         --exclude='lib/cuda' \
-         --exclude='lib/qt' \
-         --exclude='subjects/V1_average' \
-         --exclude='subjects/bert' \
-         --exclude='subjects/cvs_avg35' \
-         --exclude='subjects/cvs_avg35_inMNI152' \
-         --exclude='subjects/fsaverage3' \
-         --exclude='subjects/fsaverage4' \
-         --exclude='subjects/fsaverage5' \
-         --exclude='subjects/fsaverage6' \
-         --exclude='trctrain'
-         
+
+# RUN wget -N -O freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz --progress=bar:force https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/7.2.0/freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz && \
+COPY freesurfer.tar.gz freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz
+RUN  tar -xzf freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz -C /opt/freesurfer-7.2.0 --owner root --group root --no-same-owner --strip-components 1 --keep-newer-files \
+          --exclude='average/mult-comp-cor' \
+          --exclude='lib/cuda' \
+          --exclude='lib/qt' \
+          --exclude='subjects/V1_average' \
+          --exclude='subjects/bert' \
+          --exclude='subjects/cvs_avg35' \
+          --exclude='subjects/cvs_avg35_inMNI152' \
+          --exclude='subjects/fsaverage3' \
+          --exclude='subjects/fsaverage4' \
+          --exclude='subjects/fsaverage5' \
+          --exclude='subjects/fsaverage6' \
+          --exclude='trctrain'
+
+
+# micromamba stage
+
+FROM  debian:12-slim AS meld_git
+
+#Update the ubuntu.
+RUN apt-get -y update && apt-get install --no-install-recommends -y git ca-certificates && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+WORKDIR /meld_graph
+RUN git clone --branch dev_docker https://github.com/MELDProject/meld_graph.git .
+
+
+# freesurfer stage 
+FROM mambaorg/micromamba:latest AS micromamba
+USER root
+
+ENV MAMBA_ROOT_PREFIX="/opt/conda"
+ENV MAMBA_EXE="/bin/micromamba"
+
+#Update the ubuntu.
+RUN apt-get -y update && apt-get install --no-install-recommends -y wget gcc g++ && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+
+
+RUN mkdir /tmp/pkg
+WORKDIR /tmp
+
+RUN wget https://github.com/MELDProject/meld_graph/raw/dev_docker/environment.yml
+
+# RUN --mount=type=cache,target=/opt/conda/pkgs \
+RUN micromamba create -y -f environment.yml \
+    && micromamba clean -afy
+
+
+# meld graph stage
+FROM python:3.9-slim AS MELDgraph
+RUN mkdir -p /opt/freesurfer-7.2.0
+COPY --from=freesurfer /opt/freesurfer-7.2.0 /opt/freesurfer-7.2.0
+
+ENV DEBIAN_FRONTEND="noninteractive"
+
+#Install the prerequisite software
+RUN apt-get -y update && \
+    apt-get install -y --no-install-recommends \
+    gcc \
+    g++ \
+    time \
+    wget \
+    git \
+    tcsh \
+    vim \
+    csh \
+    bzip2 \
+    ca-certificates \
+    bc \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # COPY freesurfer/ /opt/freesurfer-7.2.0
 
@@ -44,50 +101,29 @@ RUN echo "export PYTHONPATH=\"\${PYTHONPATH}:$PWD\"" >> ~/.bashrc
 ENV FASTSURFER_HOME=/opt/fastsurfer-v1.1.2
 RUN echo "FASTSURFER_HOME=/opt/fastsurfer-v1.1.2" >> ~/.bashrc
 
-#Install the prerequisite software
-RUN --mount=type=cache,target=/var/cache/apt apt-get install -y build-essential \
-    apt-utils \
-    pip \
-    python3 \
-    time \
-    tcsh \
-    vim \
-    csh \
-    bc
-#     nano \
-
 # Add conda to path
 ENV CONDA_DIR /opt/conda
 ENV PATH=$CONDA_DIR/bin:$PATH
 
 
-# Install miniconda
-RUN wget --no-check-certificate -qO ~/miniconda.sh https://repo.continuum.io/miniconda/$CONDA_FILE  && \
-     chmod +x ~/miniconda.sh && \
-     ~/miniconda.sh -b -p /opt/conda && \
-     rm ~/miniconda.sh 
+# COPY ./environment.yml .
 
-# Activate SHELL
-SHELL ["/bin/bash", "-c"]
+COPY --from=micromamba /bin/micromamba /bin/micromamba
+COPY --from=micromamba /opt/conda/envs/meld_graph /opt/conda/envs/meld_graph
 
 # Add meld_graph code 
 RUN mkdir /app
 
-# Update conda
-RUN --mount=type=cache,target=/opt/conda/pkgs conda update -n base -c defaults conda
-RUN conda init bash
-RUN --mount=type=cache,target=/opt/conda/pkgs conda install -n base conda-libmamba-solver
-RUN conda config --set solver libmamba
-
-
 # Define working directory
 WORKDIR /app
 
-# COPY ./environment.yml .
+COPY --from=meld_git /meld_graph .
 
-RUN git clone --branch dev_docker https://github.com/MELDProject/meld_graph.git .
-# Update current conda base environment with packages for meld_graph 
-RUN --mount=type=cache,target=/opt/conda/pkgs conda env create -f environment.yml
+ENV MAMBA_ROOT_PREFIX="/opt/conda"
+ENV MAMBA_EXE="/bin/micromamba"
+RUN micromamba run -n meld_graph /bin/bash -c "pip install -e ." \
+    && micromamba shell init -s bash \
+    && echo "micromamba activate meld_graph" >> ~/.bashrc
 
 # COPY ./data data
 # COPY ./notebooks notebooks
@@ -99,12 +135,12 @@ RUN --mount=type=cache,target=/opt/conda/pkgs conda env create -f environment.ym
 # COPY ./setup.py .
 
 # Activate environment with shell because not working wih conda
-SHELL ["conda", "run", "-n", "meld_graph", "/bin/bash", "-c"]
+# SHELL ["conda", "run", "-n", "meld_graph", "/bin/bash", "-c"]
 
 # COPY ./meld_graph /app/meld_graph
 
 # Install meld_graph package
-RUN --mount=type=cache,target=/root/.cache conda run -n meld_graph /bin/bash -c "pip install -e ."
+# RUN conda run -n meld_graph /bin/bash -c "pip install -e ."
 
 # COPY ./scripts /app/scripts
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,6 @@ RUN  tar -xzf freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz -C /opt/freesurfer-7.
           --exclude='trctrain'
 
 
-# micromamba stage
 
 FROM  debian:12-slim AS meld_git
 
@@ -38,17 +37,12 @@ WORKDIR /meld_graph
 RUN git clone --branch dev_docker https://github.com/MELDProject/meld_graph.git .
 
 
-# freesurfer stage 
-FROM mambaorg/micromamba:latest AS micromamba
+# micromamba stage
+FROM continuumio/miniconda3:4.11.0 AS conda
 USER root
-
-ENV MAMBA_ROOT_PREFIX="/opt/conda"
-ENV MAMBA_EXE="/bin/micromamba"
 
 #Update the ubuntu.
 RUN apt-get -y update && apt-get install --no-install-recommends -y wget gcc g++ && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-
 
 RUN mkdir /tmp/pkg
 WORKDIR /tmp
@@ -56,12 +50,12 @@ WORKDIR /tmp
 RUN wget https://github.com/MELDProject/meld_graph/raw/dev_docker/environment.yml
 
 # RUN --mount=type=cache,target=/opt/conda/pkgs \
-RUN micromamba create -y -f environment.yml \
-    && micromamba clean -afy
+RUN conda env create -f environment.yml \
+    && conda clean -afy
 
 
 # meld graph stage
-FROM python:3.9-slim AS MELDgraph
+FROM continuumio/miniconda3:4.11.0 AS MELDgraph
 RUN mkdir -p /opt/freesurfer-7.2.0
 COPY --from=freesurfer /opt/freesurfer-7.2.0 /opt/freesurfer-7.2.0
 
@@ -103,13 +97,14 @@ RUN echo "FASTSURFER_HOME=/opt/fastsurfer-v1.1.2" >> ~/.bashrc
 
 # Add conda to path
 ENV CONDA_DIR /opt/conda
-ENV PATH=$CONDA_DIR/bin:$PATH
 
 
 # COPY ./environment.yml .
 
-COPY --from=micromamba /bin/micromamba /bin/micromamba
-COPY --from=micromamba /opt/conda/envs/meld_graph /opt/conda/envs/meld_graph
+COPY --from=conda /opt/conda/envs/meld_graph /opt/conda/envs/meld_graph
+COPY --from=conda /opt/conda/bin /opt/conda/bin
+
+ENV PATH=$CONDA_DIR/bin:$PATH
 
 # Add meld_graph code 
 RUN mkdir /app
@@ -119,11 +114,11 @@ WORKDIR /app
 
 COPY --from=meld_git /meld_graph .
 
-ENV MAMBA_ROOT_PREFIX="/opt/conda"
-ENV MAMBA_EXE="/bin/micromamba"
-RUN micromamba run -n meld_graph /bin/bash -c "pip install -e ." \
-    && micromamba shell init -s bash \
-    && echo "micromamba activate meld_graph" >> ~/.bashrc
+
+RUN conda update -n base -c defaults conda \
+  && conda init bash \
+  && conda run -n meld_graph /bin/bash -c "pip install -e ." \
+  && echo "conda activate meld_graph" >> ~/.bashrc
 
 # COPY ./data data
 # COPY ./notebooks notebooks

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get -y update && apt-get install --no-install-recommends -y wget && apt-
 RUN mkdir -p /opt/freesurfer-7.2.0
 
 # Download freesurfer
-RUN wget -N -O --no-check-certificate freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz --progress=bar:force https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/7.2.0/freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz && \
+RUN wget -N -O freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz --no-check-certificate --progress=bar:force https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/7.2.0/freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz && \
     tar -xzf freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz -C /opt/freesurfer-7.2.0 --owner root --group root --no-same-owner --strip-components 1 --keep-newer-files \
     --exclude='average/mult-comp-cor' \
     --exclude='lib/cuda' \

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,9 @@ RUN apt-get -y update && apt-get install --no-install-recommends -y wget gcc g++
 RUN mkdir /tmp/pkg
 WORKDIR /tmp
 
-RUN wget https://github.com/MELDProject/meld_graph/raw/dev_docker/environment.yml
+COPY environment.yml .
+
+ARG CACHEBUST=1
 
 # RUN --mount=type=cache,target=/opt/conda/pkgs \
 RUN micromamba create -y -f environment.yml \

--- a/environment.yml
+++ b/environment.yml
@@ -1,16 +1,18 @@
 name: meld_graph
 channels:
+  - pytorch
   - defaults
   - conda-forge
 dependencies:
   - python=3.9
-  - pytorch=1.10.0
   - pytest=7.0.1
   - jupyterlab=3.2.9
   - h5py=3.6.0
   - fpdf=1.7.2
   - scikit-image=0.18
   - pip=23.3.1
+  - pytorch=1.10.0
+  - cpuonly
   - pip:
     - potpourri3d==0.0.6
     - captum==0.6.0


### PR DESCRIPTION
Splits the Dockerfile into [multiple stages](https://docs.docker.com/build/building/multi-stage/) in order to [reduce the final size](https://uwekorn.com/2021/03/01/deploying-conda-environments-in-docker-how-to-do-it-right.html). There are also some things that I moved into a single line, and some commands that no longer seemed necessary.

It also explicitly makes the pytorch install cpu only via the pytorch channel. In the original docker, conda looked like it was downloading the cpu version anyway, but mamba resolved the cuda version which is a lot bigger. Restricting to cpu only reduces the image size and makes it more broadly usable (e.g. computers without cuda and osx).