### PR TITLE
added procps for missing uptime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ RUN apt-get -y update && \
     ca-certificates \
     bc \
     python3 \
+    procps \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
```uptime``` is currently missing from the container and leads to the following error:
```
================== Creating orig and rawavg from input =========================
 
python3.9 /opt/fastsurfer-v1.1.2/recon_surf/../FastSurferCNN/data_loader/conform.py -i /data/output/fs_outputs/MELD_H68_3T_FCD_00EP000217-20170627/mri/orig.mgz --check_only --verbose
uptime: Command not found.
upt: Subscript out of range.

ERROR - MELD_H68_3T_FCD_00EP000217-20170627: Cortical parcellation using fastsurfer failed. Please check the log at /data/output/fs_outputs/MELD_H68_3T_FCD_00EP000217-20170627/scripts/recon-all.log
```
```procps``` has been added to the list of required packages to solve this.