### PR TITLE
Duplicate IDs in the demographics cause difficult-to-interpret error messages

### DIFF
--- a/meld_graph/meld_cohort.py
+++ b/meld_graph/meld_cohort.py
@@ -533,7 +533,12 @@ class MeldSubject:
                 if matched_name == "Freesurfer_nul":
                     feature = "5.3"
                 else:
-                    feature = df.loc[self.subject_id][matched_name]
+                    feature = df.loc[self.subject_id][matched_name].drop_duplicates() # tolist() returns a list of list
+                    if len(feature) > 1:
+                        print(f"Multiple {desired_name} values found for {self.subject_id}, please check the csv file")
+                        return None
+                    else:
+                        return feature.values.tolist()[0]  # .tolist() should results in a list of lists
                 if normalize:
                     if matched_name == "Age of onset":
                         feature = np.log(feature + 1)


### PR DESCRIPTION
Solves #87.

If there are duplicates in the demographics, the code first attempts to drop them if all the fields are the same; otherwise, it informs the user.

The error message The truth value of a Series is ambiguous. is no longer returned.