### PR TITLE
V2.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v2.2.5] - 2026-02-20
+### Change in data downloading + fix in FreeSurfer segmentation
+- meld_data integrated into GitHub as Figshare platform preventing automated downloading of data
+- added Global Expert options file in $SUBJECT_DIR to fix known bug in Freesurfer pial surface reconstruction when FLAIR is used
+- save hemisphere information in csv during report creation
+- fix issue bidslayout to enable flexible config file
+
 ## [v2.2.4_gpu] - 2025-11-20
 ### Added security
 - added documentation with a first-page documentation in MELD Patient Report

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   meld_graph:
-    image: meldproject/meld_graph:v2.2.5
+    image: meldproject/meld_graph:latest
     platform: "linux/amd64"
     volumes:
       - ./docker-data:/data

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   meld_graph:
-    image: meldproject/meld_graph:latest
+    image: meldproject/meld_graph:v2.2.5
     platform: "linux/amd64"
     volumes:
       - ./docker-data:/data

--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -93,7 +93,7 @@ Our investigation suggests that FLAIR images are more heterogeneous, even on the
 
 
 If using FLAIR scan we recommend : 
-- Ensuring that the FLAIR scan is great quality (3D, no artefacts)
+- Ensuring that the FLAIR scan is excellent quality (3D, no artefacts)
 - Quality-checking the FLAIR scan preprocessed by FreeSurfer, to ensure that no intensity artefacts have been introduced. This file can be found at `output/fs_outputs/<subject_ID>/mri/FLAIR.mgz`
 - Checking the pial and white surfaces from FreeSurfer
 

--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -84,22 +84,22 @@ Solution:
 
 ### **Variability in MELD Graph results when using T1w+FLAIR scans**
 
-We have received feedback regarding inconsistencies in MELD Graph results when using T1w+FLAIR scans compared to T1w scan alone. In some cases, the tool produces different outputs for the same patient scanned at different timepoints when FLAIR is included. Our investigation suggests that FLAIR images are more heterogeneous, even on the same scanner and acquisition. This variability can affect the reliability of the MELD Graph outputs. 
+We have received feedback regarding inconsistencies in MELD Graph results when using T1w+FLAIR scans compared to T1w scan alone. In some cases, the tool produces different outputs for the same patient scanned at different timepoints when FLAIR is included. \
+Our investigation suggests that FLAIR images are more heterogeneous, even on the same scanner and acquisition. This variability can affect the reliability of the MELD Graph outputs. Addionally we have encountered examples where the FreeSurfer preprocessing on the FLAIR scan has introduced large intensity artefacts, resultings in errors in the cortical surface reconstruction.
 
-**<span style="color: red;">Recommendation**: We advise users to primarily rely on T1w scans for lesion detection. If additional sensitivity is needed, FLAIR can be added to explore other potential clusters. However, these results will need to be interpreted with extra caution, as FLAIR-based clusters may include more false positives. 
+**<span style="color: red;">Recommendation**: 
+1) We advise users to primarily rely on T1w scans for lesion detection. 
+2) If additional sensitivity is needed, FLAIR can be added to explore other potential clusters. However, these results will need to be interpreted with extra caution, as FLAIR-based clusters may include more false positives. 
+
+
+If using FLAIR scan we recommend : 
+- Ensuring that the FLAIR scan is great quality (3D, no artefacts)
+- Quality-checking the FLAIR scan preprocessed by FreeSurfer, to ensure that no intensity artefacts have been introduced. This file can be found at `output/fs_outputs/<subject_ID>/mri/FLAIR.mgz`
+- Checking the pial and white surfaces from FreeSurfer
+
+More details can be found in the ['Interpret the results'](https://meld-graph.readthedocs.io/en/latest/interpret_results.html#viewing-the-predicted-clusters-on-the-t1-and-quality-control) guidelines.
 
 To run a same subject with and without FLAIR, you should create two separate input folders with two different subject's ID such as `sub-0001` (containing only the T1w) and `sub-0001withflair` (containing T1w and FLAIR scans). You will need to run the MELD Graph pipeline twice. 
-
-### **I have an issue with FLAIR feature that does not exist**
-
-If you are running a subject with only a T1 scan and no FLAIR scan but you receive an issue like :
-```bash
-KeyError: "Unable to open object (object '.on_lh.gm_FLAIR_0.25.sm3.mgh' doesn't exist)"
-exit status 1
-```
-You are likely having this issue because you might have previously ran this same subject ID with a FLAIR scan and the FreeSurfer segmentation has been done using the FLAIR scan. Therefore, even if you remove the FLAIR scan from the input data and run again the command, the intermediate FreeSurfer outputs for that subject still contain FLAIR information, which will make the pipeline looks for for FLAIR features but fail to find them.
-
-To avoid this in the future, if you want to run a same subject with and without FLAIR, you should create two separate input folders with two different subject's ID such as `sub-0001noflair` and `sub-0001flair`.
 
 ### **I have an issue during the harmonisation**
 

--- a/meld_graph/__init__.py
+++ b/meld_graph/__init__.py
@@ -1,3 +1,3 @@
 __author__ = __maintainer__ = "MELD development team"
 __email__ = "meld.study@gmail.com"
-__version__ = "2.2.4"
+__version__ = "2.2.5"

--- a/meld_graph/download_data.py
+++ b/meld_graph/download_data.py
@@ -1,12 +1,26 @@
 import urllib.request
 import os
 import numpy as np
-from meld_graph.paths import BASE_PATH, DEFAULT_HDF5_FILE_ROOT, EXPERIMENT_PATH, MODEL_NAME, MODEL_PATH, MELD_DATA_PATH
+from meld_graph.paths import MELD_DATA_PATH
 import sys
 import shutil
 import tempfile
 
-# --- download data from figshare ---
+
+def check_data(force_download=False):
+    for folder in ['input','output','model','meld_params']:
+        exit = False
+        if os.path.exists(os.path.join(MELD_DATA_PATH, folder)):
+            print(f'The folder {folder} already exists at {MELD_DATA_PATH}.')
+            exit = True
+    if force_download:
+        print('Data to download already (partially) exists. \nData will be overwritten.') 
+    if exit and (force_download==False):
+        print('Data to download already (partially) exists. \nDownload aborted. Please delete folders or provide a new path.')
+        sys.exit()
+        
+
+
 def _fetch_url(url, fname):
     def dlProgress(count, blockSize, totalSize):
         percent = int(count*blockSize*100/totalSize)
@@ -15,89 +29,14 @@ def _fetch_url(url, fname):
             sys.stdout.flush()
     return urllib.request.urlretrieve(url, fname, reporthook=dlProgress)
 
-
-def download_test_data():
+def download_meld_graph_data():
     """
-    Download test data from figshare
+    download meld graph data from GitHub release: model, parameters and test data 
     """
-    url = "https://figshare.com/ndownloader/files/53523443?private_link=413bc45083e67c7e7a11"
-    test_data_dir = MELD_DATA_PATH
-    os.makedirs(test_data_dir, exist_ok=True)
-    print('downloading test data to '+ test_data_dir)
+    url = "https://github.com/MELDProject/meld_graph/releases/download/meld_graph_data/meld_graph_data.zip"
     with tempfile.TemporaryDirectory() as tmpdirname:
         # download to tmpdir
-        _fetch_url(url, os.path.join(tmpdirname, "test_data.zip"))
+        _fetch_url(url, os.path.join(tmpdirname, "meld_graph_data.zip"))
         # unpack
-        shutil.unpack_archive(os.path.join(tmpdirname, "test_data.zip"), test_data_dir)
-    print(f"\nunpacked data to {test_data_dir}")
-    return test_data_dir
-
-def download_meld_params():
-    """
-    Download meld parameters file from figshare
-    """
-    url = "https://figshare.com/ndownloader/files/46176921?private_link=34b4a30c57a328a1e111"
-    #print()
-    meld_params_dir = MELD_DATA_PATH
-    os.makedirs(meld_params_dir, exist_ok=True)
-    print('downloading meld parameters to '+ meld_params_dir)
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        # download to tmpdir
-        _fetch_url(url, os.path.join(tmpdirname, "meld_params.zip"))
-        # unpack
-        shutil.unpack_archive(os.path.join(tmpdirname, "meld_params.zip"), meld_params_dir)
-    print(f"\nunpacked data to {meld_params_dir}")
-    return meld_params_dir
-
-def download_models():
-    """
-    download pretrained ensemble models and return experiment_name and experiment_dir
-    """
-    url = "https://figshare.com/ndownloader/files/46176927?private_link=7f983b7321bba527ffef"
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        # download to tmpdir
-        _fetch_url(url, os.path.join(tmpdirname, "models.zip"))
-        # unpack
-        shutil.unpack_archive(os.path.join(tmpdirname, "models.zip"), os.path.dirname(EXPERIMENT_PATH))
-    print(f"\ndownloaded models to {EXPERIMENT_PATH}")
-
-# --- return path to data (and optionally download) --
-def get_test_data(force_download=False):
-    test_data_dir = os.path.join(BASE_PATH, "MELD_TEST")
-    exists_patient = os.path.exists(os.path.join(test_data_dir, DEFAULT_HDF5_FILE_ROOT.format(site_code='TEST', group='patient')))
-    exists_control = os.path.exists(os.path.join(test_data_dir, DEFAULT_HDF5_FILE_ROOT.format(site_code='TEST', group='control')))
-    test_input_dir = os.path.join(MELD_DATA_PATH, "input")
-    exists_test_input = os.path.exists(os.path.join(test_input_dir,'sub-test001'))
-    if exists_patient and exists_control and exists_test_input:
-        if force_download:
-            print("Overwriting existing test data.")
-            return download_test_data()
-        else:
-            print("Test data exists. Specify --force-download to overwrite.")
-            return test_data_dir
-    else:
-        return download_test_data()
-
-def get_model(force_download=False):
-    # test if exists and do not download then
-    if not os.path.exists(os.path.join(EXPERIMENT_PATH, MODEL_PATH)):
-        download_models()
-    else:
-        if force_download:
-            print("Overwriting existing model.")
-            download_models()
-        else:
-            print("Model exists. Specify --force-download to overwrite.")
-    return MODEL_PATH, MODEL_NAME
-
-def get_meld_params(force_download=False):
-    # test if exists and do not download then
-    if not os.path.exists(os.path.join(MELD_DATA_PATH, 'meld_params')):
-        download_meld_params()
-    else:
-        if force_download:
-            print("Overwriting existing model.")
-            download_meld_params()
-        else:
-            print("Model exists. Specify --force-download to overwrite.")
-    return MELD_DATA_PATH, 'meld_params'
+        shutil.unpack_archive(os.path.join(tmpdirname, "meld_graph_data.zip"), MELD_DATA_PATH)
+    print(f"\ndownloaded meld graph data to {MELD_DATA_PATH}")

--- a/meld_graph/download_data.py
+++ b/meld_graph/download_data.py
@@ -40,7 +40,7 @@ def _fetch_url(url, fname):
             sys.stdout.flush()
     return urllib.request.urlretrieve(url, fname, reporthook=dlProgress)
 
-def download_meld_graph_data():
+def download_meld_graph_data(meld_data_path=MELD_DATA_PATH):
     """
     download meld graph data from GitHub release: model, parameters and test data 
     """
@@ -49,5 +49,5 @@ def download_meld_graph_data():
         # download to tmpdir
         _fetch_url(url, os.path.join(tmpdirname, "meld_graph_data.zip"))
         # unpack
-        shutil.unpack_archive(os.path.join(tmpdirname, "meld_graph_data.zip"), MELD_DATA_PATH)
-    print(f"\ndownloaded meld graph data to {MELD_DATA_PATH}")
+        shutil.unpack_archive(os.path.join(tmpdirname, "meld_graph_data.zip"), meld_data_path)
+    print(f"\ndownloaded meld graph data to {meld_data_path}")

--- a/meld_graph/download_data.py
+++ b/meld_graph/download_data.py
@@ -1,11 +1,22 @@
 import urllib.request
 import os
 import numpy as np
-from meld_graph.paths import MELD_DATA_PATH
+from meld_graph.paths import MELD_DATA_PATH, DEFAULT_HDF5_FILE_ROOT, BASE_PATH
 import sys
 import shutil
 import tempfile
 
+def get_test_data(force_download=False):
+    test_data_dir = os.path.join(BASE_PATH, "MELD_TEST")
+    exists_patient = os.path.exists(os.path.join(test_data_dir, DEFAULT_HDF5_FILE_ROOT.format(site_code='TEST', group='patient')))
+    exists_control = os.path.exists(os.path.join(test_data_dir, DEFAULT_HDF5_FILE_ROOT.format(site_code='TEST', group='control')))
+    test_input_dir = os.path.join(MELD_DATA_PATH, "input")
+    exists_test_input = os.path.exists(os.path.join(test_input_dir,'sub-test001'))
+    if exists_patient and exists_control and exists_test_input:
+        print("Test data exists. Specify --force-download to overwrite.")
+        return test_data_dir
+    else:
+        print("Test data does not exists. Please run the step to prepare the classifier")
 
 def check_data(force_download=False):
     for folder in ['input','output','model','meld_params']:

--- a/meld_graph/tools_pipeline.py
+++ b/meld_graph/tools_pipeline.py
@@ -38,7 +38,7 @@ def return_bids_T1_FLAIR(bids_dir, subject_id):
         subject_id = subject_id.split('sub-')[-1]
     print(subject_id)
     # get bids structure
-    layout = bids.layout.BIDSLayout(bids_dir)
+    layout = bids.layout.BIDSLayout(bids_dir, validate=False)
     print(layout)
     # find parameters to extract bids file
     config_file = os.path.join(bids_dir, 'meld_bids_config.json')

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,3 +1,3 @@
 __author__ = __maintainer__ = "MELD development team"
 __email__ = "meld.study@gmail.com"
-__version__ = "2.2.4"
+__version__ = "2.2.5"

--- a/scripts/manage_results/plot_prediction_report.py
+++ b/scripts/manage_results/plot_prediction_report.py
@@ -550,6 +550,7 @@ def generate_prediction_report(
                 info_cl['size'] = size_clust
                 # get location
                 location = get_cluster_location(predictions[hemi] == cluster)
+                info_cl['hemi'] = hemi
                 info_cl['location'] = location
                 # get confidence
                 confidence = round(confidences[f'confidence_{cluster}']* 100,2) 

--- a/scripts/new_patient_pipeline/prepare_classifier.py
+++ b/scripts/new_patient_pipeline/prepare_classifier.py
@@ -79,7 +79,7 @@ if __name__ == '__main__':
     parser.add_argument("--update_test", action="store_true", help="only update the test data")
     args = parser.parse_args()
 
-    from meld_graph.download_data import get_test_data, get_model, get_meld_params
+    from meld_graph.download_data import download_meld_graph_data, check_data
     
     #---------------------------------------------------------------------------------
     ### Test meld license exists
@@ -87,22 +87,20 @@ if __name__ == '__main__':
     test_license()
     #---------------------------------------------------------------------------------
 
-    if args.update_test:
-        get_test_data(force_download=True)
-        print('Test data updated')
-        sys.exit()
-        
     # create and populate meld_config.ini
     if not args.skip_config:
         prepare_meld_config()
 
     # need to do this import here, because above we are setting up the meld_config.ini
     # which is read when using meld_classifier.paths
+
+
     if not args.skip_download_data:
-        print("Downloading test data")
-        get_test_data(args.force_download)
-    print("Downloading meld parameters input")
-    get_meld_params(args.force_download)
-    print("Downloading model")
-    get_model(args.force_download)
-    print("Done.")
+        # check that data don't already exist
+        check_data(args.force_download)
+        print("Downloading meld graph data")
+        download_meld_graph_data()
+        print("Done.")
+    else:
+        print("Skip downloading meld graph data")
+   

--- a/scripts/new_patient_pipeline/prepare_classifier.py
+++ b/scripts/new_patient_pipeline/prepare_classifier.py
@@ -3,7 +3,7 @@ import os
 from configparser import ConfigParser, NoOptionError
 import sys
 import shutil
-import subprocess
+import importlib
 
 
 def prepare_meld_config():
@@ -93,13 +93,15 @@ if __name__ == '__main__':
 
     # need to do this import here, because above we are setting up the meld_config.ini
     # which is read when using meld_classifier.paths
-
+    from meld_graph import paths
+    importlib.reload(paths)
+    from meld_graph.paths import MELD_DATA_PATH
 
     if not args.skip_download_data:
         # check that data don't already exist
         check_data(args.force_download)
-        print("Downloading meld graph data")
-        download_meld_graph_data()
+        print(f"Downloading meld graph data into {MELD_DATA_PATH}")
+        download_meld_graph_data(MELD_DATA_PATH)
         print("Done.")
     else:
         print("Skip downloading meld graph data")

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ try:
 except ImportError:
     __author__ = __maintainer__ = "MELD development team"
     __email__ = "meld.study@gmail.com"
-    __version__ = "2.2.4"
+    __version__ = "2.2.5"
 
 setup(
     name="meld_graph",


### PR DESCRIPTION
merge with v2.2.5: 

Release: v2.2.5 – Fix issues downloading data & FreeSurfer Pial Surface reconstruction

This release fixes issues in data downloading, FreeSurfer pial surface reconstruction, and BIDS format flexibility. This version is for CPU users only.

Updates & Fixes
📥 Change in Data Downloading
The meld data are now download from GIthub, as Figshare the platform hosting the MELD Graph model parameters results in failures during the automated downloading of the parameters. This fixes issue https://github.com/MELDProject/meld_graph/issues/102

🧠 FreeSurfer Pial Surface Fix
Added Global Expert options file in $SUBJECT_DIR to fix a https://github.com/freesurfer/freesurfer/issues/849 when reconstructing the pial surface using FLAIR images. This fix follow the recommendations provided by [FreeSurfer](https://surfer.nmr.mgh.harvard.edu/fswiki/ReleaseNotes). No major changes.

-📊 Report Enhancements

Save hemisphere information in CSV format during MELD patient report creation

🗂️ BIDS Layout Fix
Improved flexibility of the BIDS configuration file, resolving previous issues with bidslayout

🧹 Minor code cleanup for stability and maintainability